### PR TITLE
(feat): Add basic Spring Security authentication with Supabase users table

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,10 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/config/SecurityConfig.java
@@ -1,4 +1,112 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * Basic Spring Security configuration for the backend API.
+ * This class enables authentication using the USERS table stored
+ * in Supabase. It protects API endpoints and verifies user login
+ * credentials using HTTP Basic authentication.
+ *
+ * Request Flow:
+ * 1. Client sends a request to the backend.
+ * 2. Spring Security intercepts the request before it reaches controllers.
+ * 3. Credentials are read from the Authorization header.
+ * 4. The user is loaded from the database using UserDetailsService.
+ * 5. Password is validated using PasswordEncoder.
+ * 6. If valid, access is granted based on endpoint rules.
+ */
+
 package edu.wsu.cpts322.project.backend.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+/*
+ * @Configuration tells Spring this class provides application configuration.
+ * @EnableWebSecurity activates Spring Security and registers the security filter chain.
+ */
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    /*
+     * Defines the security rules for incoming HTTP requests.
+     * The SecurityFilterChain runs before controllers and decides
+     * whether a request should be allowed or rejected.
+     */
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+
+                /*
+                 * Disables CSRF protection.
+                 * CSRF mainly protects browser session-based apps.
+                 * Since this API is stateless and uses HTTP Basic authentication,
+                 * CSRF protection is not required here.
+                 */
+                .csrf(csrf -> csrf.disable())
+
+                /*
+                 * Configures session handling.
+                 * STATELESS means the server will not store login sessions.
+                 * Every request must include authentication credentials.
+                 */
+                .sessionManagement(sm ->
+                        sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                /*
+                 * Defines authorization rules for API endpoints.
+                 * Spring checks these rules after authentication succeeds.
+                 */
+                .authorizeHttpRequests(auth -> auth
+
+                        // No authentication required for public endpoints
+                        .requestMatchers("/api/public/**").permitAll()
+
+                        // Only users with ADMIN role can access admin endpoints
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
+                        // Any authenticated user can access user endpoints
+                        .requestMatchers("/api/user/**").authenticated()
+
+                        // All other endpoints remain publicly accessible
+                        .anyRequest().permitAll()
+                )
+
+                /*
+                 * Enables HTTP Basic authentication.
+                 * The client sends credentials in the Authorization header
+                 * in the format: Authorization: Basic base64(username:password).
+                 */
+                .httpBasic(withDefaults());
+
+        return http.build();
+    }
+
+    /*
+     * Defines the password encoder used during authentication.
+     * NoOpPasswordEncoder performs a direct comparison of the
+     * provided password with the stored database value.
+     *
+     * This is used here because passwords are currently stored
+     * as plain text for development simplicity.
+     */
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
 }

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package edu.wsu.cpts322.project.backend.config;
+
+public class SecurityConfig {
+}

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/controllers/auth/AuthController.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/controllers/auth/AuthController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * REST controller responsible for authentication-related test endpoints.
+ * Provides public, user, and admin routes used to verify Spring Security
+ * role-based access control and endpoint protection within the backend API.
+ */
+
+package edu.wsu.cpts322.project.backend.controllers.auth;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+
+    @GetMapping("/public/ping")
+    public String publicPing() {
+        return "public ok";
+    }
+
+    @GetMapping("/user/ping")
+    public String userPing() {
+        return "user ok";
+    }
+
+    @GetMapping("/admin/ping")
+    public String adminPing() {
+        return "admin ok";
+    }
+}

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetails.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetails.java
@@ -1,4 +1,54 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * Implementation of Spring Security's UserDetails interface for users stored
+ * in the Supabase database. This class adapts the UsersEntity model to the
+ * format required by Spring Security for authentication and authorization.
+ * It exposes user credentials, roles, and account status information used
+ * during the login and security verification process.
+ */
+
 package edu.wsu.cpts322.project.backend.database.users;
 
-public class DbUsersDetails {
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class DbUsersDetails implements UserDetails {
+
+    private final UsersEntity user;
+    public DbUsersDetails(UsersEntity user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // Spring expects roles like ROLE_ADMIN, ROLE_USER
+        String role = user.getRole(); // "ADMIN" or "USER"
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmailId();
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
 }

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetails.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetails.java
@@ -1,0 +1,4 @@
+package edu.wsu.cpts322.project.backend.database.users;
+
+public class DbUsersDetails {
+}

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetailsService.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetailsService.java
@@ -1,4 +1,39 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * Service class responsible for loading user details from the Supabase
+ * database for Spring Security authentication. Implements the UserDetailsService
+ * interface and retrieves users using the UsersRepository based on their
+ * email address. The retrieved UsersEntity is wrapped in DbUsersDetails
+ * to provide Spring Security with the required authentication information.
+ */
+
 package edu.wsu.cpts322.project.backend.database.users;
 
-public class DbUsersDetailsService {
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DbUsersDetailsService implements UserDetailsService {
+
+    private final UsersRepository usersRepository;
+
+    public DbUsersDetailsService(UsersRepository usersRepository) {
+        this.usersRepository = usersRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        UsersEntity user = usersRepository.findByEmailId(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+        return new DbUsersDetails(user);
+    }
 }

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetailsService.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/DbUsersDetailsService.java
@@ -1,0 +1,4 @@
+package edu.wsu.cpts322.project.backend.database.users;
+
+public class DbUsersDetailsService {
+}

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/UsersEntity.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/UsersEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * Entity class representing the USERS table in the SUPABASE database.
+ * Stores authentication and profile information for system users.
+ */
+
+package edu.wsu.cpts322.project.backend.database.users;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "users")
+@Data
+public class UsersEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "email_id", nullable = false, unique = true)
+    private String emailId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    // Expected values: "manager" or "user"
+    @Column(name = "role", nullable = false)
+    private String role;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "phone")
+    private String phone;
+
+    @Column(name = "reward_points")
+    private Integer rewardPoints;
+}

--- a/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/UsersRepository.java
+++ b/backend/src/main/java/edu/wsu/cpts322/project/backend/database/users/UsersRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026
+ * Washington State University
+ * CptS 322 - Software Engineering Principles
+ *
+ * Author: Paramveer Singh
+ * Project: Tickr
+ *
+ * Description:
+ * Repository interface for accessing and managing USERS table records
+ * in the Supabase database. Provides CRUD operations through Spring
+ * Data JPA and custom query methods for user lookup.
+ */
+
+package edu.wsu.cpts322.project.backend.database.users;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UsersRepository extends JpaRepository<UsersEntity, Long> {
+    Optional<UsersEntity> findByEmailId(String emailId);
+}


### PR DESCRIPTION
Description:
This PR adds basic authentication to the backend using Spring Security and the existing users table in Supabase.

Key changes:
1. Added SecurityConfig to configure Spring Security.
2. Enabled HTTP Basic authentication for login.
3. Set the API to stateless (no server sessions).
4. Disabled CSRF since the API does not use browser sessions.

Added endpoint rules:
```
/api/public/** → public
/api/user/** → authenticated users
/api/admin/** → ADMIN role
```

Added NoOpPasswordEncoder for password comparison since passwords are currently stored as plain text.

This implementation focuses only on basic authentication for the current sprint. Advanced features like password hashing, JWT, and expanded authorization can be added later.